### PR TITLE
Remove throwing basic exception

### DIFF
--- a/proposed/http-client/http-client.md
+++ b/proposed/http-client/http-client.md
@@ -47,7 +47,6 @@ interface HttpClient
    * @return ResponseInterface
    *
    * @throws \Psr\Http\Client\Exception If an error happens during processing the request.
-   * @throws \Exception             If processing the request is impossible (eg. bad configuration).
    */
   public function sendRequest(RequestInterface $request);
 ```


### PR DESCRIPTION
I think bad configuration option should be detected before calling the method in a constructor or other thing. It should not be the responsability of the sendRequest.

The only way a configuration value can mixup in this method is for a particular header on the request, but then this configuration will come from the request so we can safely throw a Network or Transfer Exception with the associated Request that cause this configuration bug.

So IMO we should not allow other exceptions as the HTTP One in the sendRequest method.

WDYT ?
