### PR TITLE
Updated text to be more clear about exceptions

### DIFF
--- a/proposed/http-client/http-client-meta.md
+++ b/proposed/http-client/http-client-meta.md
@@ -29,8 +29,7 @@ client will allow libraries to be decoupled from an implementation such as Guzzl
 ### Non-Goals
 
 * The purpose of this PSR is not to support asynchronous HTTP clients.
-* This PSR will not include how to configure a HTTP client. It does only
-specify the default behaviours.
+* This PSR will not include how to configure a HTTP client. 
 * The purpose is not to be opinionated about the use of middlewares (PSR-15).
 
 
@@ -41,8 +40,7 @@ specify the default behaviours.
 The intention of this PSR is ensure library developers that all HTTP clients have the same 
 **default behavior**. That means that all HTTP clients MUST follow Liskov substitution principle
 when no configuration is provided. The PSR does not try to restrict nor define configuration for 
-HTTP clients. An implementing library is free to be configured by the application author to follow
-redirects, to throw exceptions or any other possible setting.  
+HTTP clients.
 
 An alternative approach would be to pass configuration to the client. That approach would have
 a few drawbacks: 

--- a/proposed/http-client/http-client-meta.md
+++ b/proposed/http-client/http-client-meta.md
@@ -29,7 +29,7 @@ client will allow libraries to be decoupled from an implementation such as Guzzl
 ### Non-Goals
 
 * The purpose of this PSR is not to support asynchronous HTTP clients.
-* This PSR will not include how to configure a HTTP client. 
+* This PSR does not include how to configure a HTTP client. 
 * The purpose is not to be opinionated about the use of middlewares (PSR-15).
 
 

--- a/proposed/http-client/http-client.md
+++ b/proposed/http-client/http-client.md
@@ -21,9 +21,9 @@ implementations. This would make libraries more stable since the reduced number 
 dependencies and the likelihood to get in version conflicts is reduced.
 
 The second goal is that all HTTP clients should follow the [Liskov substitutions principle][Liskov].
-This means that all clients should act the same when sending a request. By default a HTTP client
-should not follow redirect nor throw exceptions on HTTP responses with status 4xx or 5xx.
-
+This means that all clients should act the same when sending a request. A consuming
+library SHOULD expect a HTTP client to NOT follow redirects NOR throw exceptions based
+on HTTP response statuses.
 
 ## Interfaces
 
@@ -43,10 +43,9 @@ interface HttpClient
     /**
      * Sends a PSR-7 request.
      *
-     * If a request is sent without any prior configuration, an exception MUST NOT be thrown
-     * when a response is recieved, no matter the HTTP status code.
+     * An exception MUST NOT be thrown when a response is recieved, no matter the HTTP status code.
      *
-     * If a request is sent without any prior configuration, a HTTP client MUST NOT follow redirects.
+     * The HTTP client MUST NOT follow redirects.
      *
      * The client MAY do modifications to the Request before sending it. Because PSR-7 objects are
      * immutable, one cannot assume that the object passed to HttpClient::sendRequest will be the same
@@ -148,7 +147,8 @@ use Psr\Http\Client\Exception;
  * Thrown when a response was received but the request itself failed.
  *
  * This exception MAY be thrown on HTTP response codes 4xx and 5xx.
- * This exception MUST NOT be thrown when using the client's default configuration.
+ * A comsuming library SHOULD NOT except this exception to be thrown. The
+ * exception exists for middlewares, third party library and application code.
  */
 interface HttpException extends Exception
 {


### PR DESCRIPTION
This will fix #28 

FYI @mindplay-dk, @sagikazarmark, @dbu, @kelunik

No exceptions should be thrown bases on HTTP codes. 

### Note
The php-http's PluginClient will violate the interface if configured with the ErrorPlugin. 

What do we think Guzzle will do? If the user uses an option to throw exception, should Guzzle throw `\InvalidArgument` or should it violate the interface?

The points here are:
* The interface says NEVER throw exception for HTTP status codes. 
* All consuming libraries should assume this behaviour. 
* We cannot stop HTTP clients to violate the interface. 